### PR TITLE
#4 Adiciona suporte a lifecycle rules

### DIFF
--- a/how-to-use-this-module/README.md
+++ b/how-to-use-this-module/README.md
@@ -27,6 +27,20 @@ module "ecr-mentoria" {
   source         = "git::https://github.com/mentoriaiac/iac-modulo-aws-ecs.git?ref=v1"
   repo_name      = "nome-repositório"
 
+  # OPTIONAL
+  lifecycle_rules = [
+    {
+      selection = {
+        countType   = "imageCountMoreThan"
+        countUnit   = ""
+        countNumber = 1
+        tagPrefixList = ["prod"]
+        tagStatus   = "any"
+      }
+      description = "Keep last 4 images"
+    }
+  ]
+
   tags = {
     Env          = "production"
     Team         = "time-terraform"

--- a/how-to-use-this-module/terrafile.tf
+++ b/how-to-use-this-module/terrafile.tf
@@ -8,6 +8,29 @@ module "ecr-mentoria" {
   source    = "../"
   repo_name = "api-tika"
 
+  lifecycle_rules = [
+    {
+      selection = {
+        countType   = "imageCountMoreThan"
+        countUnit   = ""
+        countNumber = 1
+        tagPrefixList = []
+        tagStatus   = "any"
+      }
+      description = "Keep last 5 images"
+    },
+    {
+      selection = {
+        countType   = "sinceimagePushed"
+        countUnit   = "days"
+        countNumber = 10
+        tagPrefixList = []
+        tagStatus   = "untagged"
+      }
+      description = "Keep images for 10 days"
+    }
+  ]
+
   tags = {
     Env          = "production"
     Team         = "tematico-terraform"

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,21 @@ resource "aws_ecr_repository" "this" {
 
   tags = var.tags
 }
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+  policy = jsonencode(
+    {
+      rules = [
+        for idx, rule in var.lifecycle_rules : 
+          merge({
+            rulePriority = idx
+            action = {
+                type = "expire"
+            }
+          }, 
+          rule)
+      ]
+    }
+  )
+}

--- a/variable.tf
+++ b/variable.tf
@@ -8,3 +8,34 @@ variable "tags" {
   default     = null
   description = "Tags para recurso"
 }
+
+variable "lifecycle_rules" {
+  type = list(object({
+    selection = object({
+      tagStatus     = string # "tagged"|"untagged"|"any"
+      tagPrefixList = list(string)
+      countType     = string # "imageCountMoreThan"|"sinceImagePushed",
+      countUnit     = string
+      countNumber   = number
+    })
+    description = string
+  }))
+  default = [{
+    selection = {
+      countType   = "imageCountMoreThan"
+      countUnit   = ""
+      countNumber = 5
+      tagPrefixList = []
+      tagStatus   = "any"
+    }
+    description = "Keep last 4 images"
+  }]
+  validation {
+    condition     = try(alltrue([for o in var.lifecycle_rules : try(length(regex("^(imageCountMoreThan|sinceImagePushed)", o.selection.countType)) != 0, false)]), false)
+    error_message = "Selection CountType should be imageCountMoreThan or sinceImagePushed."
+  }
+  validation {
+    condition     = try(alltrue([for o in var.lifecycle_rules : try(length(regex("^(tagged|untagged|any)", o.selection.tagStatus)) != 0, false)]), false)
+    error_message = "Selection Tag Status should be tagged or untagged or any."
+  }
+}


### PR DESCRIPTION
#  Adiciona suporte a *lifecycle rules*

Como solicitado no Issue #4 foi adicionado um suporte ao *lifecycle rules* para durante o provisionamento a configuração de uma regra genérica por padrão, garantidno que apenas 5 imagens de qualquer tag sejam permanentes.

Caso o usuário do modulo deseje incluir novas regras ele pode defini-las em variável sendo assim validada contra valores definidos pela AWS na documentação referência do issue e também definida alguns campos base. 

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

[issue 4](https://github.com/mentoriaiac/iac-modulo-aws-ecr/issues/4)

## Objetivo

## Referências

## Como testar

how-to-use-this-module achei que essa pasta contivesse o teste, mas não entendi muito bem como funciona, ele duplica a pasta dentro dela mesma, porém vazia e quebra. Mas o validate deu certinho, como essa não é uma mudança estrutural tenho confiança que passa. Assim que entender isso eu edito o PR. =)